### PR TITLE
Add email confirmation code sending on registration

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,2 +1,4 @@
 lombok.accessors.fluent=true
 lombok.accessors.chain=true
+
+lombok.log.fieldName=logger

--- a/src/main/java/com/odeyalo/sonata/piano/config/FactoryConfiguration.java
+++ b/src/main/java/com/odeyalo/sonata/piano/config/FactoryConfiguration.java
@@ -2,6 +2,10 @@ package com.odeyalo.sonata.piano.config;
 
 import com.odeyalo.sonata.piano.model.factory.DefaultUserFactory;
 import com.odeyalo.sonata.piano.model.factory.UserFactory;
+import com.odeyalo.sonata.piano.service.confirmation.ConfirmationCodeFactory;
+import com.odeyalo.sonata.piano.service.confirmation.EmailConfirmationMessageTemplateFactory;
+import com.odeyalo.sonata.piano.service.confirmation.PlainTextEmailConfirmationMessageTemplateFactory;
+import com.odeyalo.sonata.piano.service.confirmation.SimpleConfirmationCodeFactory;
 import com.odeyalo.sonata.piano.service.support.PasswordEncoder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,5 +16,15 @@ public class FactoryConfiguration {
     @Bean
     public UserFactory userFactory(final PasswordEncoder passwordEncoder) {
         return new DefaultUserFactory(passwordEncoder);
+    }
+
+    @Bean
+    public ConfirmationCodeFactory confirmationCodeFactory() {
+        return new SimpleConfirmationCodeFactory();
+    }
+
+    @Bean
+    public EmailConfirmationMessageTemplateFactory emailConfirmationMessageTemplateFactory() {
+        return new PlainTextEmailConfirmationMessageTemplateFactory();
     }
 }

--- a/src/main/java/com/odeyalo/sonata/piano/exception/InvalidConfirmationCodeException.java
+++ b/src/main/java/com/odeyalo/sonata/piano/exception/InvalidConfirmationCodeException.java
@@ -1,0 +1,7 @@
+package com.odeyalo.sonata.piano.exception;
+
+import lombok.experimental.StandardException;
+
+@StandardException
+public class InvalidConfirmationCodeException extends RuntimeException {
+}

--- a/src/main/java/com/odeyalo/sonata/piano/exception/MailTransportException.java
+++ b/src/main/java/com/odeyalo/sonata/piano/exception/MailTransportException.java
@@ -1,0 +1,15 @@
+package com.odeyalo.sonata.piano.exception;
+
+import lombok.experimental.StandardException;
+
+/**
+ * Exception thrown when there is a failure during the email transport process.
+ * <p>
+ * This exception indicates that an error occurred while attempting to send an email,
+ * such as network issues, invalid email configurations, or failures in the underlying
+ * email transport mechanism.
+ * </p>
+ */
+@StandardException
+public class MailTransportException extends RuntimeException {
+}

--- a/src/main/java/com/odeyalo/sonata/piano/model/factory/DefaultUserFactory.java
+++ b/src/main/java/com/odeyalo/sonata/piano/model/factory/DefaultUserFactory.java
@@ -27,4 +27,19 @@ public final class DefaultUserFactory implements UserFactory {
                 form.birthdate()
         );
     }
+
+    @Override
+    @NotNull
+    public User createUnactivatedUser(@NotNull final RegistrationForm form) {
+
+        return new User(
+                UserId.random(),
+                form.email(),
+                passwordEncoder.encode(form.password()),
+                form.gender(),
+                false,
+                false,
+                form.birthdate()
+        );
+    }
 }

--- a/src/main/java/com/odeyalo/sonata/piano/model/factory/UserFactory.java
+++ b/src/main/java/com/odeyalo/sonata/piano/model/factory/UserFactory.java
@@ -11,8 +11,16 @@ public interface UserFactory {
     /**
      * Create user based on the registration form
      * @param form registration form provided by user
-     * @return created user
+     * @return created {@link User}
      */
     @NotNull
     User createUser(@NotNull RegistrationForm form);
+
+    /**
+     * Create unactivated user from the given registration form
+     * @param form registration form provided by user
+     * @return created {@link User}
+     */
+    @NotNull
+    User createUnactivatedUser(@NotNull RegistrationForm form);
 }

--- a/src/main/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCode.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCode.java
@@ -1,0 +1,25 @@
+package com.odeyalo.sonata.piano.service.confirmation;
+
+import com.odeyalo.sonata.piano.model.User;
+import lombok.Builder;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Instant;
+
+@Value
+@Builder
+public class ConfirmationCode {
+     @NotNull
+     String value;
+     @NotNull
+     Instant issuedAt;
+     @NotNull
+     Instant expiresIn;
+     @NotNull
+     User generatedFor;
+
+     public boolean isExpired() {
+          return Instant.now().isAfter(expiresIn);
+     }
+}

--- a/src/main/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeEmailConfirmationStrategy.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeEmailConfirmationStrategy.java
@@ -4,8 +4,10 @@ import com.odeyalo.sonata.piano.model.Email;
 import com.odeyalo.sonata.piano.model.User;
 import com.odeyalo.sonata.piano.service.mail.EmailTransport;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+@Component
 public final class ConfirmationCodeEmailConfirmationStrategy implements EmailConfirmationStrategy {
     private final ConfirmationCodeService confirmationCodeService;
     private final EmailConfirmationMessageTemplateFactory confirmationMessageTemplateFactory;

--- a/src/main/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeEmailConfirmationStrategy.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeEmailConfirmationStrategy.java
@@ -1,0 +1,34 @@
+package com.odeyalo.sonata.piano.service.confirmation;
+
+import com.odeyalo.sonata.piano.model.Email;
+import com.odeyalo.sonata.piano.model.User;
+import com.odeyalo.sonata.piano.service.mail.EmailMessage;
+import com.odeyalo.sonata.piano.service.mail.EmailTransport;
+import org.jetbrains.annotations.NotNull;
+import reactor.core.publisher.Mono;
+
+public final class ConfirmationCodeEmailConfirmationStrategy implements EmailConfirmationStrategy {
+    private final EmailTransport emailTransport;
+
+    public ConfirmationCodeEmailConfirmationStrategy(final EmailTransport emailTransport) {
+        this.emailTransport = emailTransport;
+    }
+
+    @Override
+    @NotNull
+    public Mono<Void> sendConfirmationFor(@NotNull final Email emailToConfirm,
+                                          @NotNull final User user) {
+
+        final EmailMessage message = EmailMessage.builder()
+                .to(emailToConfirm)
+                .body("Your confirmation code: 123x456")
+                .subject("Your confirmation code for Sonata")
+                .html(false)
+                .build();
+
+        return emailTransport.sendEmail(message);
+    }
+}
+
+
+

--- a/src/main/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeEmailConfirmationStrategy.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeEmailConfirmationStrategy.java
@@ -2,15 +2,20 @@ package com.odeyalo.sonata.piano.service.confirmation;
 
 import com.odeyalo.sonata.piano.model.Email;
 import com.odeyalo.sonata.piano.model.User;
-import com.odeyalo.sonata.piano.service.mail.EmailMessage;
 import com.odeyalo.sonata.piano.service.mail.EmailTransport;
 import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Mono;
 
 public final class ConfirmationCodeEmailConfirmationStrategy implements EmailConfirmationStrategy {
+    private final ConfirmationCodeService confirmationCodeService;
+    private final EmailConfirmationMessageTemplateFactory confirmationMessageTemplateFactory;
     private final EmailTransport emailTransport;
 
-    public ConfirmationCodeEmailConfirmationStrategy(final EmailTransport emailTransport) {
+    public ConfirmationCodeEmailConfirmationStrategy(final ConfirmationCodeService confirmationCodeService,
+                                                     final EmailConfirmationMessageTemplateFactory confirmationMessageTemplateFactory,
+                                                     final EmailTransport emailTransport) {
+        this.confirmationCodeService = confirmationCodeService;
+        this.confirmationMessageTemplateFactory = confirmationMessageTemplateFactory;
         this.emailTransport = emailTransport;
     }
 
@@ -18,15 +23,9 @@ public final class ConfirmationCodeEmailConfirmationStrategy implements EmailCon
     @NotNull
     public Mono<Void> sendConfirmationFor(@NotNull final Email emailToConfirm,
                                           @NotNull final User user) {
-
-        final EmailMessage message = EmailMessage.builder()
-                .to(emailToConfirm)
-                .body("Your confirmation code: 123x456")
-                .subject("Your confirmation code for Sonata")
-                .html(false)
-                .build();
-
-        return emailTransport.sendEmail(message);
+        return confirmationCodeService.newConfirmationCodeFor(user)
+                .map(confirmationCode -> confirmationMessageTemplateFactory.createEmailMessage(emailToConfirm, confirmationCode))
+                .flatMap(emailTransport::sendEmail);
     }
 }
 

--- a/src/main/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeFactory.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeFactory.java
@@ -1,0 +1,36 @@
+package com.odeyalo.sonata.piano.service.confirmation;
+
+import com.odeyalo.sonata.piano.model.User;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Factory for creating {@link ConfirmationCode} instances.
+ * <p>
+ * This factory is responsible for generating confirmation codes for users,
+ * typically used for email confirmation or similar verification processes.
+ * </p>
+ *
+ * <p>
+ * Implementations of this factory might include additional logic to ensure the uniqueness,
+ * format, or expiration of confirmation codes.
+ * </p>
+ *
+ * <p>
+ * Example usage:
+ * <pre>
+ *     ConfirmationCodeFactory factory = new SimpleConfirmationCodeFactory();
+ *     ConfirmationCode code = factory.newConfirmationCodeFor(user);
+ * </pre>
+ * </p>
+ */
+public interface ConfirmationCodeFactory {
+
+    /**
+     * Generates a new {@link ConfirmationCode} for the specified {@link User}.
+     * @param user user to generate confirmation code for
+     * @return generated {@link ConfirmationCode}
+     */
+    @NotNull
+    ConfirmationCode newConfirmationCodeFor(@NotNull User user);
+
+}

--- a/src/main/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeService.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeService.java
@@ -1,0 +1,29 @@
+package com.odeyalo.sonata.piano.service.confirmation;
+
+import com.odeyalo.sonata.piano.exception.InvalidConfirmationCodeException;
+import com.odeyalo.sonata.piano.model.User;
+import org.jetbrains.annotations.NotNull;
+import reactor.core.publisher.Mono;
+
+public interface ConfirmationCodeService {
+    /**
+     * Create a new {@link ConfirmationCode} for the {@link User}
+     * @param user a user to generate confirmation code for
+     * @return {@link Mono} with generated {@link ConfirmationCode}
+     */
+    @NotNull
+    Mono<ConfirmationCode> newConfirmationCodeFor(@NotNull final User user);
+
+    /**
+     * Try to load the {@link ConfirmationCode} by its value
+     * @param value unique value of the code associated with specific {@link ConfirmationCode}
+     * @return a {@link Mono} with {@link ConfirmationCode} if code is found AND valid, otherwise:
+     * {@link Mono#empty()} - if code associated with this value DOES NOT exist
+     * {@link Mono#error(Throwable)} with {@link InvalidConfirmationCodeException}
+     *
+     * @throws InvalidConfirmationCodeException if code is invalid(expired, for example)
+     */
+    @NotNull
+    Mono<ConfirmationCode> loadConfirmationCodeByValue(@NotNull final String value);
+
+}

--- a/src/main/java/com/odeyalo/sonata/piano/service/confirmation/EmailConfirmationMessageTemplateFactory.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/confirmation/EmailConfirmationMessageTemplateFactory.java
@@ -1,0 +1,13 @@
+package com.odeyalo.sonata.piano.service.confirmation;
+
+import com.odeyalo.sonata.piano.model.Email;
+import com.odeyalo.sonata.piano.service.mail.EmailMessage;
+import org.jetbrains.annotations.NotNull;
+
+public interface EmailConfirmationMessageTemplateFactory {
+
+
+    @NotNull
+    EmailMessage createEmailMessage(@NotNull final Email to,
+                                    @NotNull final ConfirmationCode code);
+}

--- a/src/main/java/com/odeyalo/sonata/piano/service/confirmation/EmailConfirmationStrategy.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/confirmation/EmailConfirmationStrategy.java
@@ -1,6 +1,7 @@
-package com.odeyalo.sonata.piano.service.registration.email;
+package com.odeyalo.sonata.piano.service.confirmation;
 
 import com.odeyalo.sonata.piano.model.Email;
+import com.odeyalo.sonata.piano.model.User;
 import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Mono;
 
@@ -15,6 +16,7 @@ public interface EmailConfirmationStrategy {
      * {@link Mono#error(Throwable)} on any exception
      */
     @NotNull
-    Mono<Void> sendConfirmationFor(@NotNull Email emailToConfirm);
+    Mono<Void> sendConfirmationFor(@NotNull Email emailToConfirm,
+                                   @NotNull User confirmationFor);
 
 }

--- a/src/main/java/com/odeyalo/sonata/piano/service/confirmation/InMemoryConfirmationCodeService.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/confirmation/InMemoryConfirmationCodeService.java
@@ -1,0 +1,55 @@
+package com.odeyalo.sonata.piano.service.confirmation;
+
+import com.odeyalo.sonata.piano.exception.InvalidConfirmationCodeException;
+import com.odeyalo.sonata.piano.model.User;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.jetbrains.annotations.NotNull;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public final class InMemoryConfirmationCodeService implements ConfirmationCodeService {
+    private final Map<String, ConfirmationCode> confirmationCodes;
+    private final ConfirmationCodeFactory confirmationCodeFactory;
+
+    public InMemoryConfirmationCodeService(final ConfirmationCodeFactory confirmationCodeFactory) {
+        this.confirmationCodeFactory = confirmationCodeFactory;
+        this.confirmationCodes = new ConcurrentHashMap<>();
+    }
+
+    public InMemoryConfirmationCodeService(List<ConfirmationCode> confirmationCodes, final ConfirmationCodeFactory confirmationCodeFactory) {
+
+        this.confirmationCodes = confirmationCodes.stream().collect(Collectors.toMap(
+                ConfirmationCode::value,
+                Function.identity()
+        ));
+        this.confirmationCodeFactory = confirmationCodeFactory;
+    }
+
+    @Override
+    @NotNull
+    public Mono<ConfirmationCode> newConfirmationCodeFor(final @NotNull User user) {
+        return Mono.fromCallable(() -> {
+            ConfirmationCode code = confirmationCodeFactory.newConfirmationCodeFor(user);
+            confirmationCodes.put(code.value(), code);
+            return code;
+        });
+    }
+
+    @Override
+    @NotNull
+    public Mono<ConfirmationCode> loadConfirmationCodeByValue(final @NotNull String value) {
+        return Mono.justOrEmpty(confirmationCodes.get(value))
+                .flatMap(confirmationCode -> {
+                    if ( confirmationCode.isExpired() ) {
+                        return Mono.error(new InvalidConfirmationCodeException("Confirmation code is expired and can't be used!"));
+                    }
+                    return Mono.just(confirmationCode);
+                });
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/piano/service/confirmation/InMemoryConfirmationCodeService.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/confirmation/InMemoryConfirmationCodeService.java
@@ -2,11 +2,9 @@ package com.odeyalo.sonata.piano.service.confirmation;
 
 import com.odeyalo.sonata.piano.exception.InvalidConfirmationCodeException;
 import com.odeyalo.sonata.piano.model.User;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Mono;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/com/odeyalo/sonata/piano/service/confirmation/InMemoryConfirmationCodeService.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/confirmation/InMemoryConfirmationCodeService.java
@@ -3,6 +3,8 @@ package com.odeyalo.sonata.piano.service.confirmation;
 import com.odeyalo.sonata.piano.exception.InvalidConfirmationCodeException;
 import com.odeyalo.sonata.piano.model.User;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -11,10 +13,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@Component
 public final class InMemoryConfirmationCodeService implements ConfirmationCodeService {
     private final Map<String, ConfirmationCode> confirmationCodes;
     private final ConfirmationCodeFactory confirmationCodeFactory;
 
+    @Autowired
     public InMemoryConfirmationCodeService(final ConfirmationCodeFactory confirmationCodeFactory) {
         this.confirmationCodeFactory = confirmationCodeFactory;
         this.confirmationCodes = new ConcurrentHashMap<>();

--- a/src/main/java/com/odeyalo/sonata/piano/service/confirmation/MockEmailConfirmationStrategy.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/confirmation/MockEmailConfirmationStrategy.java
@@ -1,8 +1,7 @@
-package com.odeyalo.sonata.piano.service.registration.email;
+package com.odeyalo.sonata.piano.service.confirmation;
 
 import com.odeyalo.sonata.piano.model.Email;
 import com.odeyalo.sonata.piano.model.User;
-import com.odeyalo.sonata.piano.service.confirmation.EmailConfirmationStrategy;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/odeyalo/sonata/piano/service/confirmation/PlainTextEmailConfirmationMessageTemplateFactory.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/confirmation/PlainTextEmailConfirmationMessageTemplateFactory.java
@@ -1,0 +1,21 @@
+package com.odeyalo.sonata.piano.service.confirmation;
+
+import com.odeyalo.sonata.piano.model.Email;
+import com.odeyalo.sonata.piano.service.mail.EmailMessage;
+import org.jetbrains.annotations.NotNull;
+
+public final class PlainTextEmailConfirmationMessageTemplateFactory implements EmailConfirmationMessageTemplateFactory {
+
+    @Override
+    @NotNull
+    public EmailMessage createEmailMessage(@NotNull final Email to,
+                                           @NotNull final ConfirmationCode code) {
+
+        return EmailMessage.builder()
+                .to(to)
+                .body("Your confirmation code: " + code.value())
+                .subject("Your confirmation code for Sonata")
+                .html(false)
+                .build();
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/piano/service/confirmation/SimpleConfirmationCodeFactory.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/confirmation/SimpleConfirmationCodeFactory.java
@@ -1,0 +1,24 @@
+package com.odeyalo.sonata.piano.service.confirmation;
+
+import com.odeyalo.sonata.piano.model.User;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Instant;
+
+/**
+ * Implementation that just generates a six-digit confirmation code
+ */
+public final class SimpleConfirmationCodeFactory implements ConfirmationCodeFactory {
+
+    @Override
+    @NotNull
+    public ConfirmationCode newConfirmationCodeFor(@NotNull final User user) {
+        String value = RandomStringUtils.randomNumeric(6);
+        return new ConfirmationCode(value,
+                Instant.now(),
+                Instant.now().plusSeconds(360),
+                user
+        );
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/piano/service/mail/EmailMessage.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/mail/EmailMessage.java
@@ -1,0 +1,33 @@
+package com.odeyalo.sonata.piano.service.mail;
+
+import com.odeyalo.sonata.piano.model.Email;
+import lombok.Builder;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents an email message with the necessary details for sending.
+ * Note, that this class is immutable and can't be changed after creation!
+ * <p>
+ * This class holds the key information required to compose and send an email,
+ * including the recipient's email address, subject, and the message body, etc.
+ * </p>
+ *
+ * <p>
+ * To make the {@link EmailMessage} an HTML message,
+ * set the {@link #html} flag to {@code true}.
+ * By default, HTML mode is set to {@code false}
+ * </p>
+ */
+@Value
+@Builder
+public class EmailMessage {
+    @NotNull
+    Email to;
+    @NotNull
+    String subject;
+    @NotNull
+    String body;
+
+    boolean html;
+}

--- a/src/main/java/com/odeyalo/sonata/piano/service/mail/EmailTransport.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/mail/EmailTransport.java
@@ -1,0 +1,22 @@
+package com.odeyalo.sonata.piano.service.mail;
+
+import com.odeyalo.sonata.piano.exception.MailTransportException;
+import org.jetbrains.annotations.NotNull;
+import reactor.core.publisher.Mono;
+
+/**
+ * Transport to send the email messages in reactive way
+ */
+public interface EmailTransport {
+    /**
+     * Send the supplied message to {@link EmailMessage#to()}
+     * @param message message payload with all necessary info
+     * @return a {@link Mono} with {@link Void} on success,
+     * {@link Mono#error(Throwable)} with {@link MailTransportException} on failure
+     *
+     * @throws MailTransportException if message was failed to be sent
+     */
+    @NotNull
+    Mono<Void> sendEmail(@NotNull final EmailMessage message);
+
+}

--- a/src/main/java/com/odeyalo/sonata/piano/service/mail/NoOpEmailTransport.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/mail/NoOpEmailTransport.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 @Component
-@Profile({"dev", "local"})
+@Profile({"dev", "local", "test"})
 @Log4j2
 public final class NoOpEmailTransport implements EmailTransport {
 

--- a/src/main/java/com/odeyalo/sonata/piano/service/mail/NoOpEmailTransport.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/mail/NoOpEmailTransport.java
@@ -1,0 +1,23 @@
+package com.odeyalo.sonata.piano.service.mail;
+
+import lombok.extern.log4j.Log4j2;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+@Profile({"dev", "local"})
+@Log4j2
+public final class NoOpEmailTransport implements EmailTransport {
+
+    public NoOpEmailTransport() {
+        logger.warn("NoOpEmailTransport is used for [DEV] and [LOCAL] mode. All EmailMessage(s) will be printed in log stream");
+    }
+
+    @Override
+    @NotNull
+    public Mono<Void> sendEmail(@NotNull final EmailMessage message) {
+        return Mono.fromRunnable(() -> logger.info("Sending the email message: {}", message));
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/piano/service/registration/email/EmailConfirmationStrategy.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/registration/email/EmailConfirmationStrategy.java
@@ -1,0 +1,20 @@
+package com.odeyalo.sonata.piano.service.registration.email;
+
+import com.odeyalo.sonata.piano.model.Email;
+import org.jetbrains.annotations.NotNull;
+import reactor.core.publisher.Mono;
+
+/**
+ * A strategy to confirm email provided by user
+ */
+public interface EmailConfirmationStrategy {
+    /**
+     * Send the confirmation to provided email
+     * @param emailToConfirm email that needs to be confirmed
+     * @return a {@link Mono} with {@link Void} on success,
+     * {@link Mono#error(Throwable)} on any exception
+     */
+    @NotNull
+    Mono<Void> sendConfirmationFor(@NotNull Email emailToConfirm);
+
+}

--- a/src/main/java/com/odeyalo/sonata/piano/service/registration/email/MockEmailConfirmationStrategy.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/registration/email/MockEmailConfirmationStrategy.java
@@ -1,6 +1,8 @@
 package com.odeyalo.sonata.piano.service.registration.email;
 
 import com.odeyalo.sonata.piano.model.Email;
+import com.odeyalo.sonata.piano.model.User;
+import com.odeyalo.sonata.piano.service.confirmation.EmailConfirmationStrategy;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -11,7 +13,8 @@ public final class MockEmailConfirmationStrategy implements EmailConfirmationStr
     private boolean wasSent = false;
 
     @Override
-    public @NotNull Mono<Void> sendConfirmationFor(@NotNull final Email email) {
+    public @NotNull Mono<Void> sendConfirmationFor(@NotNull final Email email,
+                                                   @NotNull final User user) {
         final String code = RandomStringUtils.randomNumeric(6);
         return Mono.fromRunnable(() -> {
             logger.info("Send confirmation code {} for {} ", code, email);

--- a/src/main/java/com/odeyalo/sonata/piano/service/registration/email/MockEmailConfirmationStrategy.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/registration/email/MockEmailConfirmationStrategy.java
@@ -1,0 +1,25 @@
+package com.odeyalo.sonata.piano.service.registration.email;
+
+import com.odeyalo.sonata.piano.model.Email;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.jetbrains.annotations.NotNull;
+import reactor.core.publisher.Mono;
+
+@Log4j2
+public final class MockEmailConfirmationStrategy implements EmailConfirmationStrategy {
+    private boolean wasSent = false;
+
+    @Override
+    public @NotNull Mono<Void> sendConfirmationFor(@NotNull final Email email) {
+        final String code = RandomStringUtils.randomNumeric(6);
+        return Mono.fromRunnable(() -> {
+            logger.info("Send confirmation code {} for {} ", code, email);
+            wasSent = true;
+        });
+    }
+
+    public boolean wasSent() {
+        return wasSent;
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManager.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManager.java
@@ -9,6 +9,9 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+/**
+ * An implementation of {@link EmailPasswordRegistrationManager} that requires email confirmation to activate the user
+ */
 @Component
 @RequiredArgsConstructor
 public final class SecureEmailPasswordRegistrationManager implements EmailPasswordRegistrationManager {

--- a/src/main/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManager.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManager.java
@@ -3,6 +3,7 @@ package com.odeyalo.sonata.piano.service.registration.email;
 import com.odeyalo.sonata.piano.model.User;
 import com.odeyalo.sonata.piano.model.factory.UserFactory;
 import com.odeyalo.sonata.piano.service.UserService;
+import com.odeyalo.sonata.piano.service.confirmation.EmailConfirmationStrategy;
 import com.odeyalo.sonata.piano.service.registration.support.RegistrationFormValidator;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
@@ -33,7 +34,7 @@ public final class SecureEmailPasswordRegistrationManager implements EmailPasswo
         final User user = userFactory.createUnactivatedUser(form);
 
         return userService.save(user)
-                .flatMap(u -> emailConfirmationStrategy.sendConfirmationFor(u.email()).thenReturn(u))
+                .flatMap(u -> emailConfirmationStrategy.sendConfirmationFor(u.email(), u).thenReturn(u))
                 .map(RegistrationResult::confirmEmailFor);
     }
 }

--- a/src/main/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManager.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManager.java
@@ -1,0 +1,33 @@
+package com.odeyalo.sonata.piano.service.registration.email;
+
+import com.odeyalo.sonata.piano.model.User;
+import com.odeyalo.sonata.piano.model.factory.UserFactory;
+import com.odeyalo.sonata.piano.service.UserService;
+import com.odeyalo.sonata.piano.service.registration.support.RegistrationFormValidator;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public final class SecureEmailPasswordRegistrationManager implements EmailPasswordRegistrationManager {
+    private final UserFactory userFactory;
+    private final UserService userService;
+    private final RegistrationFormValidator registrationFormValidator;
+
+    @Override
+    @NotNull
+    public Mono<RegistrationResult> registerUser(@NotNull final RegistrationForm form) {
+
+        return registrationFormValidator.validate(form)
+                .then(Mono.defer(() -> tryRegisterUser(form)));
+    }
+
+    @NotNull
+    private Mono<RegistrationResult> tryRegisterUser(@NotNull final RegistrationForm form) {
+        final User user = userFactory.createUser(form);
+        return userService.save(user)
+                .map(RegistrationResult::completedFor);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManager.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManager.java
@@ -28,6 +28,6 @@ public final class SecureEmailPasswordRegistrationManager implements EmailPasswo
     private Mono<RegistrationResult> tryRegisterUser(@NotNull final RegistrationForm form) {
         final User user = userFactory.createUser(form);
         return userService.save(user)
-                .map(RegistrationResult::completedFor);
+                .map(RegistrationResult::confirmEmailFor);
     }
 }

--- a/src/main/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManager.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManager.java
@@ -18,6 +18,7 @@ public final class SecureEmailPasswordRegistrationManager implements EmailPasswo
     private final UserFactory userFactory;
     private final UserService userService;
     private final RegistrationFormValidator registrationFormValidator;
+    private final EmailConfirmationStrategy emailConfirmationStrategy;
 
     @Override
     @NotNull
@@ -32,6 +33,7 @@ public final class SecureEmailPasswordRegistrationManager implements EmailPasswo
         final User user = userFactory.createUnactivatedUser(form);
 
         return userService.save(user)
+                .flatMap(u -> emailConfirmationStrategy.sendConfirmationFor(u.email()).thenReturn(u))
                 .map(RegistrationResult::confirmEmailFor);
     }
 }

--- a/src/main/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManager.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManager.java
@@ -26,7 +26,8 @@ public final class SecureEmailPasswordRegistrationManager implements EmailPasswo
 
     @NotNull
     private Mono<RegistrationResult> tryRegisterUser(@NotNull final RegistrationForm form) {
-        final User user = userFactory.createUser(form);
+        final User user = userFactory.createUnactivatedUser(form);
+
         return userService.save(user)
                 .map(RegistrationResult::confirmEmailFor);
     }

--- a/src/main/java/com/odeyalo/sonata/piano/service/registration/email/UnsecureEmailPasswordRegistrationManager.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/registration/email/UnsecureEmailPasswordRegistrationManager.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
-@Component
+//@Component
 @RequiredArgsConstructor
 public final class UnsecureEmailPasswordRegistrationManager implements EmailPasswordRegistrationManager {
     private final UserFactory userFactory;

--- a/src/main/java/com/odeyalo/sonata/piano/service/registration/email/UnsecureEmailPasswordRegistrationManager.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/registration/email/UnsecureEmailPasswordRegistrationManager.java
@@ -6,10 +6,8 @@ import com.odeyalo.sonata.piano.service.UserService;
 import com.odeyalo.sonata.piano.service.registration.support.RegistrationFormValidator;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
-//@Component
 @RequiredArgsConstructor
 public final class UnsecureEmailPasswordRegistrationManager implements EmailPasswordRegistrationManager {
     private final UserFactory userFactory;

--- a/src/main/java/com/odeyalo/sonata/piano/service/registration/email/UnsecureEmailPasswordRegistrationManager.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/registration/email/UnsecureEmailPasswordRegistrationManager.java
@@ -5,12 +5,7 @@ import com.odeyalo.sonata.piano.model.factory.UserFactory;
 import com.odeyalo.sonata.piano.service.UserService;
 import com.odeyalo.sonata.piano.service.registration.support.RegistrationFormValidator;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.java.Log;
-import lombok.extern.log4j.Log4j;
-import lombok.extern.log4j.Log4j2;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 

--- a/src/main/java/com/odeyalo/sonata/piano/service/registration/email/UnsecureEmailPasswordRegistrationManager.java
+++ b/src/main/java/com/odeyalo/sonata/piano/service/registration/email/UnsecureEmailPasswordRegistrationManager.java
@@ -4,23 +4,22 @@ import com.odeyalo.sonata.piano.model.User;
 import com.odeyalo.sonata.piano.model.factory.UserFactory;
 import com.odeyalo.sonata.piano.service.UserService;
 import com.odeyalo.sonata.piano.service.registration.support.RegistrationFormValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
+import lombok.extern.log4j.Log4j;
+import lombok.extern.log4j.Log4j2;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 @Component
+@RequiredArgsConstructor
 public final class UnsecureEmailPasswordRegistrationManager implements EmailPasswordRegistrationManager {
     private final UserFactory userFactory;
     private final UserService userService;
     private final RegistrationFormValidator registrationFormValidator;
-
-    public UnsecureEmailPasswordRegistrationManager(final UserFactory userFactory,
-                                                    final UserService userService,
-                                                    final RegistrationFormValidator registrationFormValidator) {
-        this.userFactory = userFactory;
-        this.userService = userService;
-        this.registrationFormValidator = registrationFormValidator;
-    }
 
     @Override
     @NotNull
@@ -30,7 +29,8 @@ public final class UnsecureEmailPasswordRegistrationManager implements EmailPass
                 .then(Mono.defer(() -> tryRegisterUser(form)));
     }
 
-    private @NotNull Mono<RegistrationResult> tryRegisterUser(final @NotNull RegistrationForm form) {
+    @NotNull
+    private Mono<RegistrationResult> tryRegisterUser(@NotNull final RegistrationForm form) {
         final User user = userFactory.createUser(form);
         return userService.save(user)
                 .map(RegistrationResult::completedFor);

--- a/src/main/java/testing/mock/PrefixBodyEmailConfirmationMessageTemplateFactory.java
+++ b/src/main/java/testing/mock/PrefixBodyEmailConfirmationMessageTemplateFactory.java
@@ -1,0 +1,25 @@
+package testing.mock;
+
+import com.odeyalo.sonata.piano.model.Email;
+import com.odeyalo.sonata.piano.service.confirmation.ConfirmationCode;
+import com.odeyalo.sonata.piano.service.confirmation.EmailConfirmationMessageTemplateFactory;
+import com.odeyalo.sonata.piano.service.mail.EmailMessage;
+import org.jetbrains.annotations.NotNull;
+
+public final class PrefixBodyEmailConfirmationMessageTemplateFactory implements EmailConfirmationMessageTemplateFactory {
+    private final String bodyPrefix;
+
+    public PrefixBodyEmailConfirmationMessageTemplateFactory(final String bodyPrefix) {
+        this.bodyPrefix = bodyPrefix;
+    }
+
+    @Override
+    public @NotNull EmailMessage createEmailMessage(final @NotNull Email to, final @NotNull ConfirmationCode code) {
+        return EmailMessage.builder()
+                .to(to)
+                .body(bodyPrefix + code.value())
+                .subject("Your confirmation code for Sonata")
+                .html(false)
+                .build();
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/piano/PianoApplicationTests.java
+++ b/src/test/java/com/odeyalo/sonata/piano/PianoApplicationTests.java
@@ -2,8 +2,10 @@ package com.odeyalo.sonata.piano;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class PianoApplicationTests {
 
     @Test

--- a/src/test/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeEmailConfirmationStrategyTest.java
+++ b/src/test/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeEmailConfirmationStrategyTest.java
@@ -1,0 +1,29 @@
+package com.odeyalo.sonata.piano.service.confirmation;
+
+import com.odeyalo.sonata.piano.model.Email;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+import testing.UserFaker;
+import testing.mock.MockEmailTransport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfirmationCodeEmailConfirmationStrategyTest {
+
+    @Test
+    void shouldSendConfirmationCodeToProvidedEmail() {
+        MockEmailTransport emailTransport = new MockEmailTransport();
+
+        var testable = new ConfirmationCodeEmailConfirmationStrategy(
+                emailTransport
+        );
+
+        testable.sendConfirmationFor(Email.valueOf("odeyalo@gmail.com"), UserFaker.create().get())
+                .as(StepVerifier::create)
+                .verifyComplete();
+
+        assertThat(emailTransport.getSentMessages()).hasSize(1);
+        assertThat(emailTransport.getFirstMessage().to()).isEqualTo(Email.valueOf("odeyalo@gmail.com"));
+    }
+
+}

--- a/src/test/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeEmailConfirmationStrategyTest.java
+++ b/src/test/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeEmailConfirmationStrategyTest.java
@@ -1,12 +1,17 @@
 package com.odeyalo.sonata.piano.service.confirmation;
 
 import com.odeyalo.sonata.piano.model.Email;
+import com.odeyalo.sonata.piano.service.mail.EmailMessage;
 import com.odeyalo.sonata.piano.service.mail.EmailTransport;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import testing.UserFaker;
 import testing.mock.MockEmailTransport;
+import testing.mock.PrefixBodyEmailConfirmationMessageTemplateFactory;
+import testing.mock.StaticEmailConfirmationMessageTemplateFactory;
+
+import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,9 +33,69 @@ class ConfirmationCodeEmailConfirmationStrategyTest {
         assertThat(emailTransport.getFirstMessage().to()).isEqualTo(Email.valueOf("odeyalo@gmail.com"));
     }
 
+    @Test
+    void shouldSendConfirmationCodeMessageTemplateThatWasGenerated() {
+
+        var message = EmailMessage.builder()
+                .to(Email.valueOf("odeyalo@gmail.com"))
+                .subject("Hello from Sonata!")
+                .body("<p> Hello </p>")
+                .html(true)
+                .build();
+
+        var emailTransport = new MockEmailTransport();
+
+        var templateFactory = new StaticEmailConfirmationMessageTemplateFactory(
+                message
+        );
+
+        var testable = TestableBuilder.builder()
+                .templateMessageFactory(templateFactory)
+                .sendWith(emailTransport)
+                .build();
+
+        testable.sendConfirmationFor(Email.valueOf("odeyalo@gmail.com"), UserFaker.create().get())
+                .as(StepVerifier::create)
+                .verifyComplete();
+
+        assertThat(emailTransport.getSentMessages()).hasSize(1);
+        assertThat(emailTransport.getFirstMessage()).isEqualTo(message);
+    }
+
+    @Test
+    void shouldSendConfirmationCodeThatWasGenerated() {
+        var emailTransport = new MockEmailTransport();
+
+        ConfirmationCodeFactory codeFactory = user -> new ConfirmationCode(
+                "123",
+                Instant.now(),
+                Instant.now().plusSeconds(360),
+                user
+        );
+
+        var templateFactory = new PrefixBodyEmailConfirmationMessageTemplateFactory(
+                "Your confirmation code: "
+        );
+
+        var testable = TestableBuilder.builder()
+                .confirmationCodeFactory(codeFactory)
+                .templateMessageFactory(templateFactory)
+                .sendWith(emailTransport)
+                .build();
+
+        testable.sendConfirmationFor(Email.valueOf("odeyalo@gmail.com"), UserFaker.create().get())
+                .as(StepVerifier::create)
+                .verifyComplete();
+
+        assertThat(emailTransport.getSentMessages()).hasSize(1);
+        assertThat(emailTransport.getFirstMessage().body()).isEqualTo("Your confirmation code: 123");
+    }
+
 
     static class TestableBuilder {
         private EmailTransport emailTransport = new MockEmailTransport();
+        private EmailConfirmationMessageTemplateFactory templateMessageFactory = new PlainTextEmailConfirmationMessageTemplateFactory();
+        private ConfirmationCodeFactory confirmationCodeFactory = new SimpleConfirmationCodeFactory();
 
         public static TestableBuilder builder() {
             return new TestableBuilder();
@@ -41,8 +106,20 @@ class ConfirmationCodeEmailConfirmationStrategyTest {
             return this;
         }
 
+        public TestableBuilder templateMessageFactory(@NotNull final EmailConfirmationMessageTemplateFactory templateFactory) {
+            this.templateMessageFactory = templateFactory;
+            return this;
+        }
+
+        public TestableBuilder confirmationCodeFactory(ConfirmationCodeFactory confirmationCodeFactory) {
+            this.confirmationCodeFactory = confirmationCodeFactory;
+            return this;
+        }
+
         public ConfirmationCodeEmailConfirmationStrategy build() {
             return new ConfirmationCodeEmailConfirmationStrategy(
+                    new InMemoryConfirmationCodeService(confirmationCodeFactory),
+                    templateMessageFactory,
                     emailTransport
             );
         }

--- a/src/test/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeEmailConfirmationStrategyTest.java
+++ b/src/test/java/com/odeyalo/sonata/piano/service/confirmation/ConfirmationCodeEmailConfirmationStrategyTest.java
@@ -1,6 +1,8 @@
 package com.odeyalo.sonata.piano.service.confirmation;
 
 import com.odeyalo.sonata.piano.model.Email;
+import com.odeyalo.sonata.piano.service.mail.EmailTransport;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import testing.UserFaker;
@@ -14,9 +16,9 @@ class ConfirmationCodeEmailConfirmationStrategyTest {
     void shouldSendConfirmationCodeToProvidedEmail() {
         MockEmailTransport emailTransport = new MockEmailTransport();
 
-        var testable = new ConfirmationCodeEmailConfirmationStrategy(
-                emailTransport
-        );
+        var testable = TestableBuilder.builder()
+                .sendWith(emailTransport)
+                .build();
 
         testable.sendConfirmationFor(Email.valueOf("odeyalo@gmail.com"), UserFaker.create().get())
                 .as(StepVerifier::create)
@@ -26,4 +28,23 @@ class ConfirmationCodeEmailConfirmationStrategyTest {
         assertThat(emailTransport.getFirstMessage().to()).isEqualTo(Email.valueOf("odeyalo@gmail.com"));
     }
 
+
+    static class TestableBuilder {
+        private EmailTransport emailTransport = new MockEmailTransport();
+
+        public static TestableBuilder builder() {
+            return new TestableBuilder();
+        }
+
+        public TestableBuilder sendWith(@NotNull final EmailTransport transport) {
+            this.emailTransport = transport;
+            return this;
+        }
+
+        public ConfirmationCodeEmailConfirmationStrategy build() {
+            return new ConfirmationCodeEmailConfirmationStrategy(
+                    emailTransport
+            );
+        }
+    }
 }

--- a/src/test/java/com/odeyalo/sonata/piano/service/confirmation/InMemoryConfirmationCodeServiceTest.java
+++ b/src/test/java/com/odeyalo/sonata/piano/service/confirmation/InMemoryConfirmationCodeServiceTest.java
@@ -1,0 +1,79 @@
+package com.odeyalo.sonata.piano.service.confirmation;
+
+import com.odeyalo.sonata.piano.exception.InvalidConfirmationCodeException;
+import com.odeyalo.sonata.piano.model.User;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+import testing.UserFaker;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class InMemoryConfirmationCodeServiceTest {
+
+
+    @Test
+    void shouldReturnGeneratedConfirmationCode() {
+        final User user = UserFaker.create().get();
+
+        InMemoryConfirmationCodeService testable = new InMemoryConfirmationCodeService(new SimpleConfirmationCodeFactory());
+
+        testable.newConfirmationCodeFor(user)
+                .as(StepVerifier::create)
+                .assertNext(res -> {
+                    assertThat(res.generatedFor()).isEqualTo(user);
+                    assertThat(res.value()).isNotBlank();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldFindGeneratedConfirmationCodeThatWasGenerated() {
+        final User user = UserFaker.create().get();
+
+        InMemoryConfirmationCodeService testable = new InMemoryConfirmationCodeService(new SimpleConfirmationCodeFactory());
+
+        ConfirmationCode code = testable.newConfirmationCodeFor(user).block();
+
+        assertThat(code).isNotNull();
+
+        testable.loadConfirmationCodeByValue(code.value())
+                .as(StepVerifier::create)
+                .assertNext(found -> assertThat(found).isEqualTo(code))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnNothingIfCodeWithValueDoesNotExist() {
+        InMemoryConfirmationCodeService testable = new InMemoryConfirmationCodeService(new SimpleConfirmationCodeFactory());
+
+        testable.loadConfirmationCodeByValue("not_exist")
+                .as(StepVerifier::create)
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnErrorIfConfirmationCodeIsExpired() {
+        final User user = UserFaker.create().get();
+
+        ConfirmationCode code = ConfirmationCode.builder()
+                .value("123456")
+                .issuedAt(Instant.now().minusSeconds(200))
+                .expiresIn(Instant.now().minusSeconds(100))
+                .generatedFor(user)
+                .build();
+
+        InMemoryConfirmationCodeService testable = new InMemoryConfirmationCodeService(
+                List.of(code),
+                new SimpleConfirmationCodeFactory()
+        );
+
+        testable.loadConfirmationCodeByValue("123456")
+                .as(StepVerifier::create)
+                .expectError(InvalidConfirmationCodeException.class)
+                .verify();
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/piano/service/confirmation/InMemoryConfirmationCodeServiceTest.java
+++ b/src/test/java/com/odeyalo/sonata/piano/service/confirmation/InMemoryConfirmationCodeServiceTest.java
@@ -10,7 +10,6 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 class InMemoryConfirmationCodeServiceTest {
 

--- a/src/test/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManagerTest.java
+++ b/src/test/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManagerTest.java
@@ -1,0 +1,277 @@
+package com.odeyalo.sonata.piano.service.registration.email;
+
+import com.odeyalo.sonata.piano.exception.BirthdatePolicyViolationException;
+import com.odeyalo.sonata.piano.exception.EmailAddressAlreadyInUseException;
+import com.odeyalo.sonata.piano.model.Gender;
+import com.odeyalo.sonata.piano.model.User;
+import com.odeyalo.sonata.piano.model.factory.DefaultUserFactory;
+import com.odeyalo.sonata.piano.service.InMemoryUserService;
+import com.odeyalo.sonata.piano.service.registration.policy.BirthdatePolicy;
+import com.odeyalo.sonata.piano.service.registration.policy.SimplePridicateBirthdatePolicy;
+import com.odeyalo.sonata.piano.service.registration.support.BirthdatePolicyRegistrationFormValidationStep;
+import com.odeyalo.sonata.piano.service.registration.support.ChainRegistrationFormValidator;
+import com.odeyalo.sonata.piano.service.registration.support.RegistrationFormValidator;
+import com.odeyalo.sonata.piano.service.support.PasswordEncoder;
+import com.odeyalo.sonata.piano.service.support.TestingPasswordEncoder;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import reactor.test.StepVerifier;
+import testing.RegistrationFormFaker;
+import testing.UserFaker;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.odeyalo.sonata.piano.service.registration.email.RegistrationResult.NextAction.COMPLETED;
+import static com.odeyalo.sonata.piano.service.registration.email.SecureEmailPasswordRegistrationManagerTest.BirthdatePolicies.alwaysDeny;
+import static com.odeyalo.sonata.piano.service.registration.email.SecureEmailPasswordRegistrationManagerTest.BirthdatePolicies.olderThan;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecureEmailPasswordRegistrationManagerTest {
+
+    @Test
+    void shouldReturnCompletedStatusForValidRegistrationForm() {
+        SecureEmailPasswordRegistrationManager testable = TestableBuilder.builder().build();
+
+        RegistrationForm registrationForm = RegistrationFormFaker.create().get();
+
+        testable.registerUser(registrationForm)
+                .as(StepVerifier::create)
+                .assertNext(result -> assertThat(result.nextStep()).isEqualTo(COMPLETED))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnUserWithTheSameEmailAddressAsWasProvidedInRegistrationForm() {
+        SecureEmailPasswordRegistrationManager testable = TestableBuilder.builder().build();
+
+        RegistrationForm registrationForm = RegistrationFormFaker.create()
+                .withEmail("miku.nakano@gmail.com")
+                .get();
+
+        testable.registerUser(registrationForm)
+                .as(StepVerifier::create)
+                .assertNext(result -> assertThat(result.registeredUser().email().asString()).isEqualTo("miku.nakano@gmail.com"))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnActivatedUserAfterRegistrationComplete() {
+        SecureEmailPasswordRegistrationManager testable = TestableBuilder.builder().build();
+
+        RegistrationForm registrationForm = RegistrationFormFaker.create().get();
+
+        testable.registerUser(registrationForm)
+                .as(StepVerifier::create)
+                .assertNext(result -> assertThat(result.registeredUser().isActivated()).isTrue())
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldIndicateThatUserEmailIsNotConfirmedAfterRegistrationComplete() {
+        SecureEmailPasswordRegistrationManager testable = TestableBuilder.builder().build();
+
+        RegistrationForm registrationForm = RegistrationFormFaker.create().get();
+
+        testable.registerUser(registrationForm)
+                .as(StepVerifier::create)
+                .assertNext(result -> assertThat(result.registeredUser().isEmailConfirmed()).isFalse())
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnUserWithEncodedPasswordThatMatchesProvidedOne() {
+        TestingPasswordEncoder passwordEncoder = new TestingPasswordEncoder();
+
+        SecureEmailPasswordRegistrationManager testable = TestableBuilder.builder()
+                .withPasswordEncoder(passwordEncoder)
+                .build();
+
+        RegistrationForm registrationForm = RegistrationFormFaker.create()
+                .withPassword("ilovemikunakan0")
+                .get();
+
+        RegistrationResult result = testable.registerUser(registrationForm).block();
+
+        assertThat(result).isNotNull();
+
+        boolean passwordMatches = passwordEncoder.matches("ilovemikunakan0", result.registeredUser().password());
+
+        assertThat(passwordMatches).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(Gender.class)
+    void shouldReturnUserWithTheSameGenderAsWasProvided(@NotNull final Gender gender) {
+        SecureEmailPasswordRegistrationManager testable = TestableBuilder.builder().build();
+
+        RegistrationForm registrationForm = RegistrationFormFaker.create()
+                .withGender(gender)
+                .get();
+
+        testable.registerUser(registrationForm)
+                .as(StepVerifier::create)
+                .assertNext(result -> assertThat(result.registeredUser().gender()).isEqualTo(gender))
+                .verifyComplete();
+
+    }
+
+    @Test
+    void shouldReturnUserWithTheSameBirthdateAsWasProvided() {
+        SecureEmailPasswordRegistrationManager testable = TestableBuilder.builder().build();
+
+        LocalDate birthdate = LocalDate.of(2000, Month.MAY, 5);
+
+        RegistrationForm registrationForm = RegistrationFormFaker.create()
+                .withBirthdate(birthdate)
+                .get();
+
+        RegistrationResult result = testable.registerUser(registrationForm).block();
+
+        assertThat(result).isNotNull();
+
+        assertThat(result.registeredUser().birthdate()).isEqualTo(birthdate);
+    }
+
+    @Test
+    void shouldGenerateUserWithGeneratedId() {
+        SecureEmailPasswordRegistrationManager testable = TestableBuilder.builder().build();
+
+        RegistrationForm registrationForm = RegistrationFormFaker.create().get();
+
+        testable.registerUser(registrationForm)
+                .as(StepVerifier::create)
+                .assertNext(result -> assertThat(result.registeredUser().id()).isNotNull())
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldGenerateUserWithContextUri() {
+        SecureEmailPasswordRegistrationManager testable = TestableBuilder.builder().build();
+
+        RegistrationForm registrationForm = RegistrationFormFaker.create().get();
+
+        testable.registerUser(registrationForm)
+                .as(StepVerifier::create)
+                .assertNext(result -> assertThat(result.registeredUser().contextUri().asString()).isEqualTo("sonata:user:" + result.registeredUser().id().value()))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnErrorIfUserWithTheSameEmailAlreadyExist() {
+        SecureEmailPasswordRegistrationManager testable = TestableBuilder.builder()
+                .withUsers("miku.nakano@gmail.com")
+                .build();
+
+        RegistrationForm registrationForm = RegistrationFormFaker.create()
+                .withEmail("miku.nakano@gmail.com")
+                .get();
+
+        testable.registerUser(registrationForm)
+                .as(StepVerifier::create)
+                .expectError(EmailAddressAlreadyInUseException.class)
+                .verify();
+    }
+
+    @Test
+    void shouldReturnErrorIfBirthdatePolicyIsViolated() {
+        SecureEmailPasswordRegistrationManager testable = TestableBuilder.builder()
+                .withBirthdatePolicy(alwaysDeny())
+                .build();
+
+        RegistrationForm registrationForm = RegistrationFormFaker.create()
+                .withBirthdate("2024-04-24")
+                .get();
+
+        testable.registerUser(registrationForm)
+                .as(StepVerifier::create)
+                .expectError(BirthdatePolicyViolationException.class)
+                .verify();
+    }
+
+    @Test
+    void shouldSaveRegisteredUser() {
+        SecureEmailPasswordRegistrationManager testable = TestableBuilder.builder()
+                .build();
+
+        RegistrationForm registrationForm = RegistrationFormFaker.create()
+                .withEmail("miku.nakano@gmail.com")
+                .get();
+
+        testable.registerUser(registrationForm)
+                .as(StepVerifier::create)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        // verify that user is saved and we can't register with the same values(email, for example)
+        testable.registerUser(registrationForm)
+                .as(StepVerifier::create)
+                .expectError(EmailAddressAlreadyInUseException.class)
+                .verify();
+    }
+
+    private static class TestableBuilder {
+        private PasswordEncoder passwordEncoder = new TestingPasswordEncoder();
+        private final List<User> registeredUsers = new ArrayList<>();
+        private BirthdatePolicy birthdatePolicy = olderThan(13);
+
+        public static TestableBuilder builder() {
+            return new TestableBuilder();
+        }
+
+        public TestableBuilder withPasswordEncoder(final PasswordEncoder passwordEncoder) {
+            this.passwordEncoder = passwordEncoder;
+            return this;
+        }
+
+        public TestableBuilder withUsers(@NotNull final String... emails) {
+
+            for (final String email : emails) {
+                User user = UserFaker.create().withEmail(email).get();
+
+                registeredUsers.add(user);
+            }
+
+            return this;
+        }
+
+        public TestableBuilder withBirthdatePolicy(@NotNull final BirthdatePolicy birthdatePolicy) {
+            this.birthdatePolicy = birthdatePolicy;
+            return this;
+        }
+
+        public SecureEmailPasswordRegistrationManager build() {
+
+            return new SecureEmailPasswordRegistrationManager(
+                    new DefaultUserFactory(passwordEncoder),
+                    new InMemoryUserService(registeredUsers),
+                    newRegistrationFormValidator()
+            );
+        }
+
+        private RegistrationFormValidator newRegistrationFormValidator() {
+            return new ChainRegistrationFormValidator(List.of(
+                    new BirthdatePolicyRegistrationFormValidationStep(birthdatePolicy)
+            ));
+        }
+    }
+
+    static class BirthdatePolicies {
+
+        static BirthdatePolicy olderThan(final int minimalAllowedAge) {
+            return new SimplePridicateBirthdatePolicy(
+                    birthdate -> birthdate.isOlderThan(minimalAllowedAge)
+            );
+        }
+
+        static BirthdatePolicy alwaysDeny() {
+            return new SimplePridicateBirthdatePolicy(
+                    birthdate -> false
+            );
+        }
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManagerTest.java
+++ b/src/test/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManagerTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.odeyalo.sonata.piano.service.registration.email.RegistrationResult.NextAction.COMPLETED;
+import static com.odeyalo.sonata.piano.service.registration.email.RegistrationResult.NextAction.CONFIRM_EMAIL;
 import static com.odeyalo.sonata.piano.service.registration.email.SecureEmailPasswordRegistrationManagerTest.BirthdatePolicies.alwaysDeny;
 import static com.odeyalo.sonata.piano.service.registration.email.SecureEmailPasswordRegistrationManagerTest.BirthdatePolicies.olderThan;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,14 +35,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SecureEmailPasswordRegistrationManagerTest {
 
     @Test
-    void shouldReturnCompletedStatusForValidRegistrationForm() {
+    void shouldReturnEmailConfirmationRequiredStatusForValidRegistrationForm() {
         SecureEmailPasswordRegistrationManager testable = TestableBuilder.builder().build();
 
         RegistrationForm registrationForm = RegistrationFormFaker.create().get();
 
         testable.registerUser(registrationForm)
                 .as(StepVerifier::create)
-                .assertNext(result -> assertThat(result.nextStep()).isEqualTo(COMPLETED))
+                .assertNext(result -> assertThat(result.nextStep()).isEqualTo(CONFIRM_EMAIL))
                 .verifyComplete();
     }
 

--- a/src/test/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManagerTest.java
+++ b/src/test/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManagerTest.java
@@ -61,14 +61,14 @@ class SecureEmailPasswordRegistrationManagerTest {
     }
 
     @Test
-    void shouldReturnActivatedUserAfterRegistrationComplete() {
+    void shouldReturnNotActivatedUserAfterRegistrationComplete() {
         SecureEmailPasswordRegistrationManager testable = TestableBuilder.builder().build();
 
         RegistrationForm registrationForm = RegistrationFormFaker.create().get();
 
         testable.registerUser(registrationForm)
                 .as(StepVerifier::create)
-                .assertNext(result -> assertThat(result.registeredUser().isActivated()).isTrue())
+                .assertNext(result -> assertThat(result.registeredUser().isActivated()).isFalse())
                 .verifyComplete();
     }
 

--- a/src/test/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManagerTest.java
+++ b/src/test/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManagerTest.java
@@ -26,7 +26,6 @@ import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.odeyalo.sonata.piano.service.registration.email.RegistrationResult.NextAction.COMPLETED;
 import static com.odeyalo.sonata.piano.service.registration.email.RegistrationResult.NextAction.CONFIRM_EMAIL;
 import static com.odeyalo.sonata.piano.service.registration.email.SecureEmailPasswordRegistrationManagerTest.BirthdatePolicies.alwaysDeny;
 import static com.odeyalo.sonata.piano.service.registration.email.SecureEmailPasswordRegistrationManagerTest.BirthdatePolicies.olderThan;

--- a/src/test/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManagerTest.java
+++ b/src/test/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManagerTest.java
@@ -6,6 +6,7 @@ import com.odeyalo.sonata.piano.model.Gender;
 import com.odeyalo.sonata.piano.model.User;
 import com.odeyalo.sonata.piano.model.factory.DefaultUserFactory;
 import com.odeyalo.sonata.piano.service.InMemoryUserService;
+import com.odeyalo.sonata.piano.service.confirmation.EmailConfirmationStrategy;
 import com.odeyalo.sonata.piano.service.registration.policy.BirthdatePolicy;
 import com.odeyalo.sonata.piano.service.registration.policy.SimplePridicateBirthdatePolicy;
 import com.odeyalo.sonata.piano.service.registration.support.BirthdatePolicyRegistrationFormValidationStep;

--- a/src/test/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManagerTest.java
+++ b/src/test/java/com/odeyalo/sonata/piano/service/registration/email/SecureEmailPasswordRegistrationManagerTest.java
@@ -7,6 +7,7 @@ import com.odeyalo.sonata.piano.model.User;
 import com.odeyalo.sonata.piano.model.factory.DefaultUserFactory;
 import com.odeyalo.sonata.piano.service.InMemoryUserService;
 import com.odeyalo.sonata.piano.service.confirmation.EmailConfirmationStrategy;
+import com.odeyalo.sonata.piano.service.confirmation.MockEmailConfirmationStrategy;
 import com.odeyalo.sonata.piano.service.registration.policy.BirthdatePolicy;
 import com.odeyalo.sonata.piano.service.registration.policy.SimplePridicateBirthdatePolicy;
 import com.odeyalo.sonata.piano.service.registration.support.BirthdatePolicyRegistrationFormValidationStep;

--- a/src/test/java/testing/mock/MockEmailTransport.java
+++ b/src/test/java/testing/mock/MockEmailTransport.java
@@ -1,0 +1,32 @@
+package testing.mock;
+
+import com.odeyalo.sonata.piano.service.mail.EmailMessage;
+import com.odeyalo.sonata.piano.service.mail.EmailTransport;
+import org.jetbrains.annotations.NotNull;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Simple mock for unit tests
+ */
+public class MockEmailTransport implements EmailTransport {
+    private final List<EmailMessage> sentMessages = new CopyOnWriteArrayList<>();
+
+    @Override
+    @NotNull
+    public Mono<Void> sendEmail(@NotNull final EmailMessage message) {
+        return Mono.fromRunnable(() -> sentMessages.add(message));
+    }
+
+    @NotNull
+    public List<EmailMessage> getSentMessages() {
+        return sentMessages;
+    }
+
+    @NotNull
+    public EmailMessage getFirstMessage() {
+        return sentMessages.get(0);
+    }
+}

--- a/src/test/java/testing/mock/StaticEmailConfirmationMessageTemplateFactory.java
+++ b/src/test/java/testing/mock/StaticEmailConfirmationMessageTemplateFactory.java
@@ -1,0 +1,21 @@
+package testing.mock;
+
+import com.odeyalo.sonata.piano.model.Email;
+import com.odeyalo.sonata.piano.service.confirmation.ConfirmationCode;
+import com.odeyalo.sonata.piano.service.confirmation.EmailConfirmationMessageTemplateFactory;
+import com.odeyalo.sonata.piano.service.mail.EmailMessage;
+import org.jetbrains.annotations.NotNull;
+
+public final class StaticEmailConfirmationMessageTemplateFactory implements EmailConfirmationMessageTemplateFactory {
+    private final EmailMessage stub;
+
+    public StaticEmailConfirmationMessageTemplateFactory(final EmailMessage stub) {
+        this.stub = stub;
+    }
+
+    @Override
+    public @NotNull EmailMessage createEmailMessage(final @NotNull Email to,
+                                                    final @NotNull ConfirmationCode code) {
+        return stub;
+    }
+}


### PR DESCRIPTION
Added email confirmation code sending on registration
Added tests


Now email is being sent to provided user's email with confirmation code that can be used to activate user account and verify its email.

To override the template that will be sent to user's email implement your custom [EmailConfirmationMessageTemplateFactory](https://github.com/Project-Sonata/Piano/blob/a1ba06f384dfdef639e855ca5e0b2622e7f12fb3/src/main/java/com/odeyalo/sonata/piano/service/confirmation/EmailConfirmationMessageTemplateFactory.java) 



By default, verification code is generated by [SimpleConfirmationCodeFactory](https://github.com/Project-Sonata/Piano/blob/a1ba06f384dfdef639e855ca5e0b2622e7f12fb3/src/main/java/com/odeyalo/sonata/piano/service/confirmation/SimpleConfirmationCodeFactory.java ) that applies following rules:
- six-digit code
- 360 seconds confirmation code lifetime

To override the email provider(now mocked one is used, [NoOpEmailTransport](https://github.com/Project-Sonata/Piano/blob/a1ba06f384dfdef639e855ca5e0b2622e7f12fb3/src/main/java/com/odeyalo/sonata/piano/service/mail/NoOpEmailTransport.java)), to create a custom one, please, implement your own [EmailTransport](https://github.com/Project-Sonata/Piano/blob/a1ba06f384dfdef639e855ca5e0b2622e7f12fb3/src/main/java/com/odeyalo/sonata/piano/service/mail/EmailTransport.java) interface